### PR TITLE
 Sanitize note-derived HTML, and scope webview file access

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -25,6 +25,7 @@
         "@tauri-apps/plugin-shell": "^2.2.0",
         "@tauri-apps/plugin-updater": "^2.3.0",
         "concurrently": "^9.2.1",
+        "dompurify": "^3.4.13",
         "katex": "^0.16.38",
         "mermaid": "^11.13.0",
         "next": "16.1.6",
@@ -5157,9 +5158,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.1.tgz",
-      "integrity": "sha512-JahakDAIg1gyOm7dlgWSDjV4n7Ip2PKR55NIT6jrMfIgLFgWo81vdr1/QGqWtFNRqXP9UV71oVePtjqS2ebnPw==",
+      "version": "3.4.13",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+      "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -35,6 +35,7 @@
     "@tauri-apps/plugin-shell": "^2.2.0",
     "@tauri-apps/plugin-updater": "^2.3.0",
     "concurrently": "^9.2.1",
+    "dompurify": "^3.4.13",
     "katex": "^0.16.38",
     "mermaid": "^11.13.0",
     "next": "16.1.6",

--- a/desktop/src-tauri/src/commands_dialog.rs
+++ b/desktop/src-tauri/src/commands_dialog.rs
@@ -1,7 +1,19 @@
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::PathBuf;
+use tauri::Manager;
 use tauri_plugin_dialog::{DialogExt, FilePath};
+
+use crate::AppState;
+
+/// Record every path the user picked so the file and opener commands will
+/// accept it. Selecting a path in a native dialog is the user's grant.
+fn grant(app: &tauri::AppHandle, paths: &[String]) {
+    let state = app.state::<AppState>();
+    for p in paths {
+        state.scope.grant(p);
+    }
+}
 
 #[derive(Debug, Serialize)]
 pub struct OpenedFile {
@@ -27,6 +39,7 @@ pub async fn dialog_open_file(app: tauri::AppHandle) -> Option<OpenedFile> {
         .blocking_pick_file();
     let fp = picked?;
     let path_str = fp_to_string(fp)?;
+    grant(&app, std::slice::from_ref(&path_str));
     let content = fs::read_to_string(&path_str).ok()?;
     Some(OpenedFile { file_path: path_str, content })
 }
@@ -34,7 +47,9 @@ pub async fn dialog_open_file(app: tauri::AppHandle) -> Option<OpenedFile> {
 #[tauri::command]
 pub async fn dialog_open_folder(app: tauri::AppHandle) -> Option<String> {
     let picked = app.dialog().file().blocking_pick_folder();
-    fp_to_string(picked?)
+    let path = fp_to_string(picked?)?;
+    grant(&app, std::slice::from_ref(&path));
+    Some(path)
 }
 
 #[derive(Debug, Deserialize)]
@@ -113,6 +128,7 @@ pub async fn dialog_show_open(
             .unwrap_or_default()
     };
 
+    grant(&app, &picked);
     OpenDialogResult {
         canceled: picked.is_empty(),
         file_paths: picked,
@@ -140,7 +156,9 @@ pub async fn dialog_save_file(app: tauri::AppHandle, args: SaveFileInput) -> Opt
             builder = builder.set_file_name(file.to_string_lossy().to_string());
         }
     }
-    builder.blocking_save_file().and_then(fp_to_string)
+    let path = builder.blocking_save_file().and_then(fp_to_string)?;
+    grant(&app, std::slice::from_ref(&path));
+    Some(path)
 }
 
 #[tauri::command]
@@ -158,5 +176,7 @@ pub async fn dialog_save_html(app: tauri::AppHandle, args: SaveFileInput) -> Opt
             builder = builder.set_file_name(file.to_string_lossy().to_string());
         }
     }
-    builder.blocking_save_file().and_then(fp_to_string)
+    let path = builder.blocking_save_file().and_then(fp_to_string)?;
+    grant(&app, std::slice::from_ref(&path));
+    Some(path)
 }

--- a/desktop/src-tauri/src/commands_fs.rs
+++ b/desktop/src-tauri/src/commands_fs.rs
@@ -2,6 +2,22 @@ use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::Path;
+use tauri::Manager;
+
+use crate::AppState;
+
+/// True when the webview may touch this path. See `crate::scope`.
+///
+/// Every command below is reachable by any script running in the webview, so
+/// each one has to ask. A refusal is logged and returned as the command's
+/// ordinary failure value rather than an error, matching the existing contract.
+fn allowed(app: &tauri::AppHandle, path: &str) -> bool {
+    let ok = app.state::<AppState>().scope.is_allowed(Path::new(path));
+    if !ok {
+        log::warn!("[fs] refused access outside the permitted scope: {path}");
+    }
+    ok
+}
 
 #[derive(Debug, Serialize)]
 pub struct DirEntry {
@@ -12,12 +28,18 @@ pub struct DirEntry {
 }
 
 #[tauri::command]
-pub async fn fs_read_file(file_path: String) -> Option<String> {
+pub async fn fs_read_file(app: tauri::AppHandle, file_path: String) -> Option<String> {
+    if !allowed(&app, &file_path) {
+        return None;
+    }
     fs::read_to_string(&file_path).ok()
 }
 
 #[tauri::command]
-pub async fn fs_read_binary_file(file_path: String) -> Option<String> {
+pub async fn fs_read_binary_file(app: tauri::AppHandle, file_path: String) -> Option<String> {
+    if !allowed(&app, &file_path) {
+        return None;
+    }
     let bytes = fs::read(&file_path).ok()?;
     Some(B64.encode(bytes))
 }
@@ -30,7 +52,10 @@ pub struct WriteFileInput {
 }
 
 #[tauri::command]
-pub async fn fs_write_file(args: WriteFileInput) -> bool {
+pub async fn fs_write_file(app: tauri::AppHandle, args: WriteFileInput) -> bool {
+    if !allowed(&app, &args.file_path) {
+        return false;
+    }
     let path = Path::new(&args.file_path);
     if let Some(parent) = path.parent() {
         let _ = fs::create_dir_all(parent);
@@ -39,7 +64,10 @@ pub async fn fs_write_file(args: WriteFileInput) -> bool {
 }
 
 #[tauri::command]
-pub async fn fs_read_dir(dir_path: String) -> Vec<DirEntry> {
+pub async fn fs_read_dir(app: tauri::AppHandle, dir_path: String) -> Vec<DirEntry> {
+    if !allowed(&app, &dir_path) {
+        return Vec::new();
+    }
     let entries = match fs::read_dir(&dir_path) {
         Ok(e) => e,
         Err(_) => return Vec::new(),
@@ -72,7 +100,10 @@ pub async fn fs_read_dir(dir_path: String) -> Vec<DirEntry> {
 }
 
 #[tauri::command]
-pub async fn fs_create_file(file_path: String) -> bool {
+pub async fn fs_create_file(app: tauri::AppHandle, file_path: String) -> bool {
+    if !allowed(&app, &file_path) {
+        return false;
+    }
     let path = Path::new(&file_path);
     if let Some(parent) = path.parent() {
         let _ = fs::create_dir_all(parent);
@@ -81,12 +112,18 @@ pub async fn fs_create_file(file_path: String) -> bool {
 }
 
 #[tauri::command]
-pub async fn fs_delete_file(file_path: String) -> bool {
+pub async fn fs_delete_file(app: tauri::AppHandle, file_path: String) -> bool {
+    if !allowed(&app, &file_path) {
+        return false;
+    }
     fs::remove_file(&file_path).is_ok()
 }
 
 #[tauri::command]
-pub async fn fs_delete_dir(dir_path: String) -> bool {
+pub async fn fs_delete_dir(app: tauri::AppHandle, dir_path: String) -> bool {
+    if !allowed(&app, &dir_path) {
+        return false;
+    }
     fs::remove_dir_all(&dir_path).is_ok()
 }
 
@@ -99,12 +136,18 @@ pub struct RenameInput {
 }
 
 #[tauri::command]
-pub async fn fs_rename(args: RenameInput) -> bool {
+pub async fn fs_rename(app: tauri::AppHandle, args: RenameInput) -> bool {
+    if !allowed(&app, &args.old_path) || !allowed(&app, &args.new_path) {
+        return false;
+    }
     fs::rename(&args.old_path, &args.new_path).is_ok()
 }
 
 #[tauri::command]
-pub async fn fs_create_dir(dir_path: String) -> bool {
+pub async fn fs_create_dir(app: tauri::AppHandle, dir_path: String) -> bool {
+    if !allowed(&app, &dir_path) {
+        return false;
+    }
     fs::create_dir_all(&dir_path).is_ok()
 }
 
@@ -115,7 +158,10 @@ pub struct CopyInput {
 }
 
 #[tauri::command]
-pub async fn fs_copy_file(args: CopyInput) -> bool {
+pub async fn fs_copy_file(app: tauri::AppHandle, args: CopyInput) -> bool {
+    if !allowed(&app, &args.src) || !allowed(&app, &args.dest) {
+        return false;
+    }
     let dest = Path::new(&args.dest);
     if let Some(parent) = dest.parent() {
         let _ = fs::create_dir_all(parent);
@@ -131,7 +177,10 @@ pub struct WriteBinaryInput {
 }
 
 #[tauri::command]
-pub async fn fs_write_binary_file(args: WriteBinaryInput) -> bool {
+pub async fn fs_write_binary_file(app: tauri::AppHandle, args: WriteBinaryInput) -> bool {
+    if !allowed(&app, &args.file_path) {
+        return false;
+    }
     let bytes = match B64.decode(args.base64.as_bytes()) {
         Ok(b) => b,
         Err(_) => return false,
@@ -164,7 +213,10 @@ pub struct SearchInput {
 }
 
 #[tauri::command]
-pub async fn fs_search_in_files(args: SearchInput) -> Vec<SearchHit> {
+pub async fn fs_search_in_files(app: tauri::AppHandle, args: SearchInput) -> Vec<SearchHit> {
+    if !allowed(&app, &args.dir) {
+        return Vec::new();
+    }
     let mut results = Vec::new();
     if args.query.is_empty() || args.dir.is_empty() {
         return results;
@@ -233,7 +285,10 @@ fn rel_path(base: &str, full: &str) -> String {
 }
 
 #[tauri::command]
-pub async fn fs_list_all_files(dir: String) -> Vec<ListedFile> {
+pub async fn fs_list_all_files(app: tauri::AppHandle, dir: String) -> Vec<ListedFile> {
+    if !allowed(&app, &dir) {
+        return Vec::new();
+    }
     let mut out = Vec::new();
     if dir.is_empty() {
         return out;
@@ -288,7 +343,10 @@ pub struct StatsFile {
 }
 
 #[tauri::command]
-pub async fn fs_get_file_stats(dir: String) -> Vec<StatsFile> {
+pub async fn fs_get_file_stats(app: tauri::AppHandle, dir: String) -> Vec<StatsFile> {
+    if !allowed(&app, &dir) {
+        return Vec::new();
+    }
     let mut out = Vec::new();
     if dir.is_empty() {
         return out;

--- a/desktop/src-tauri/src/commands_fs.rs
+++ b/desktop/src-tauri/src/commands_fs.rs
@@ -4,6 +4,7 @@ use std::fs;
 use std::path::Path;
 use tauri::Manager;
 
+use crate::scope::PathScope;
 use crate::AppState;
 
 /// True when the webview may touch this path. See `crate::scope`.
@@ -223,7 +224,7 @@ pub async fn fs_search_in_files(app: tauri::AppHandle, args: SearchInput) -> Vec
     }
     let lower = args.query.to_lowercase();
 
-    fn walk(dir: &Path, lower: &str, results: &mut Vec<SearchHit>) {
+    fn walk(dir: &Path, lower: &str, results: &mut Vec<SearchHit>, scope: &PathScope) {
         if results.len() >= 200 {
             return;
         }
@@ -238,9 +239,16 @@ pub async fn fs_search_in_files(app: tauri::AppHandle, args: SearchInput) -> Vec
                 continue;
             }
             let path = entry.path();
-            let is_dir = entry.file_type().map(|t| t.is_dir()).unwrap_or(false);
+            let Ok(file_type) = entry.file_type() else {
+                continue;
+            };
+            if !scope.may_visit(&file_type, &path) {
+                log::warn!("[fs] skipped a link out of the permitted scope: {path:?}");
+                continue;
+            }
+            let is_dir = file_type.is_dir();
             if is_dir {
-                walk(&path, lower, results);
+                walk(&path, lower, results, scope);
                 if results.len() >= 200 {
                     return;
                 }
@@ -264,7 +272,12 @@ pub async fn fs_search_in_files(app: tauri::AppHandle, args: SearchInput) -> Vec
         }
     }
 
-    walk(Path::new(&args.dir), &lower, &mut results);
+    walk(
+        Path::new(&args.dir),
+        &lower,
+        &mut results,
+        &app.state::<AppState>().scope,
+    );
     results
 }
 
@@ -294,7 +307,7 @@ pub async fn fs_list_all_files(app: tauri::AppHandle, dir: String) -> Vec<Listed
         return out;
     }
 
-    fn walk(dir: &Path, base: &str, out: &mut Vec<ListedFile>) {
+    fn walk(dir: &Path, base: &str, out: &mut Vec<ListedFile>, scope: &PathScope) {
         let entries = match fs::read_dir(dir) {
             Ok(e) => e,
             Err(_) => return,
@@ -306,9 +319,15 @@ pub async fn fs_list_all_files(app: tauri::AppHandle, dir: String) -> Vec<Listed
                 continue;
             }
             let path = entry.path();
-            let is_dir = entry.file_type().map(|t| t.is_dir()).unwrap_or(false);
+            let Ok(file_type) = entry.file_type() else {
+                continue;
+            };
+            if !scope.may_visit(&file_type, &path) {
+                continue;
+            }
+            let is_dir = file_type.is_dir();
             if is_dir {
-                walk(&path, base, out);
+                walk(&path, base, out, scope);
             } else if name_s.ends_with(".md") || name_s.ends_with(".markdown") {
                 let full = path.to_string_lossy().into_owned();
                 let trimmed_name = name_s
@@ -324,7 +343,12 @@ pub async fn fs_list_all_files(app: tauri::AppHandle, dir: String) -> Vec<Listed
         }
     }
 
-    walk(Path::new(&dir), &dir, &mut out);
+    walk(
+        Path::new(&dir),
+        &dir,
+        &mut out,
+        &app.state::<AppState>().scope,
+    );
     out
 }
 
@@ -358,7 +382,7 @@ pub async fn fs_get_file_stats(app: tauri::AppHandle, dir: String) -> Vec<StatsF
             .unwrap_or(0.0)
     }
 
-    fn walk(dir: &Path, base: &str, out: &mut Vec<StatsFile>) {
+    fn walk(dir: &Path, base: &str, out: &mut Vec<StatsFile>, scope: &PathScope) {
         let entries = match fs::read_dir(dir) {
             Ok(e) => e,
             Err(_) => return,
@@ -370,9 +394,15 @@ pub async fn fs_get_file_stats(app: tauri::AppHandle, dir: String) -> Vec<StatsF
                 continue;
             }
             let path = entry.path();
-            let is_dir = entry.file_type().map(|t| t.is_dir()).unwrap_or(false);
+            let Ok(file_type) = entry.file_type() else {
+                continue;
+            };
+            if !scope.may_visit(&file_type, &path) {
+                continue;
+            }
+            let is_dir = file_type.is_dir();
             if is_dir {
-                walk(&path, base, out);
+                walk(&path, base, out, scope);
             } else if name_s.ends_with(".md") || name_s.ends_with(".markdown") {
                 if let Ok(meta) = entry.metadata() {
                     let full = path.to_string_lossy().into_owned();
@@ -394,6 +424,11 @@ pub async fn fs_get_file_stats(app: tauri::AppHandle, dir: String) -> Vec<StatsF
         }
     }
 
-    walk(Path::new(&dir), &dir, &mut out);
+    walk(
+        Path::new(&dir),
+        &dir,
+        &mut out,
+        &app.state::<AppState>().scope,
+    );
     out
 }

--- a/desktop/src-tauri/src/commands_shell.rs
+++ b/desktop/src-tauri/src/commands_shell.rs
@@ -1,4 +1,8 @@
+use std::path::Path;
+use tauri::Manager;
 use tauri_plugin_opener::OpenerExt;
+
+use crate::AppState;
 
 #[tauri::command]
 pub async fn shell_open_external(app: tauri::AppHandle, url: String) {
@@ -7,8 +11,22 @@ pub async fn shell_open_external(app: tauri::AppHandle, url: String) {
     }
 }
 
+/// Hand a path to the OS opener.
+///
+/// The opener resolves the file's registered handler and starts it, so an
+/// unrestricted version of this command turns any write primitive in the
+/// webview into process execution. Only paths the user selected in a native
+/// dialog this session are accepted; vault membership is deliberately not
+/// enough, because note content and attachments arrive from sync, the web
+/// clipper and the MCP server without the user ever choosing them.
 #[tauri::command]
-pub async fn shell_open_path(app: tauri::AppHandle, file_path: String) -> String {
-    let _ = app.opener().open_path(&file_path, None::<&str>);
-    String::new()
+pub async fn shell_open_path(app: tauri::AppHandle, file_path: String) -> Result<(), String> {
+    let state = app.state::<AppState>();
+    if !state.scope.is_granted(Path::new(&file_path)) {
+        log::warn!("[shell] refused open_path for a path the user did not select: {file_path}");
+        return Err("refusing to open a path that was not selected by the user".into());
+    }
+    app.opener()
+        .open_path(&file_path, None::<&str>)
+        .map_err(|e| e.to_string())
 }

--- a/desktop/src-tauri/src/commands_shell.rs
+++ b/desktop/src-tauri/src/commands_shell.rs
@@ -15,14 +15,15 @@ pub async fn shell_open_external(app: tauri::AppHandle, url: String) {
 ///
 /// The opener resolves the file's registered handler and starts it, so an
 /// unrestricted version of this command turns any write primitive in the
-/// webview into process execution. Only paths the user selected in a native
-/// dialog this session are accepted; vault membership is deliberately not
-/// enough, because note content and attachments arrive from sync, the web
-/// clipper and the MCP server without the user ever choosing them.
+/// webview into process execution. Only the exact paths the user named in a
+/// native dialog this session are accepted; neither vault membership nor
+/// sitting inside a picked folder is enough, because a file can reach either
+/// place without the user ever choosing it — through sync, the web clipper, the
+/// MCP server, or a write from the renderer itself.
 #[tauri::command]
 pub async fn shell_open_path(app: tauri::AppHandle, file_path: String) -> Result<(), String> {
     let state = app.state::<AppState>();
-    if !state.scope.is_granted(Path::new(&file_path)) {
+    if !state.scope.is_openable(Path::new(&file_path)) {
         log::warn!("[shell] refused open_path for a path the user did not select: {file_path}");
         return Err("refusing to open a path that was not selected by the user".into());
     }

--- a/desktop/src-tauri/src/commands_workspace.rs
+++ b/desktop/src-tauri/src/commands_workspace.rs
@@ -2,9 +2,29 @@ use serde::Deserialize;
 use serde_json::Value;
 use std::fs;
 use std::path::Path;
+use tauri::Manager;
+
+use crate::AppState;
+
+/// True when the webview may use this path as a vault root. See `crate::scope`.
+///
+/// These commands take a directory from the renderer and read or write
+/// `<dir>/.noteriv/workspace.json` inside it, so an unscoped version is a read
+/// and write primitive for any directory on the machine. The renderer only ever
+/// passes the active vault's path.
+fn allowed(app: &tauri::AppHandle, path: &str) -> bool {
+    let ok = app.state::<AppState>().scope.is_allowed(Path::new(path));
+    if !ok {
+        log::warn!("[workspace] refused access outside the permitted scope: {path}");
+    }
+    ok
+}
 
 #[tauri::command]
-pub async fn workspace_load(vault_path: String) -> Option<Value> {
+pub async fn workspace_load(app: tauri::AppHandle, vault_path: String) -> Option<Value> {
+    if !allowed(&app, &vault_path) {
+        return None;
+    }
     let p = Path::new(&vault_path).join(".noteriv").join("workspace.json");
     let raw = fs::read_to_string(p).ok()?;
     serde_json::from_str(&raw).ok()
@@ -18,7 +38,10 @@ pub struct WorkspaceSaveInput {
 }
 
 #[tauri::command]
-pub async fn workspace_save(args: WorkspaceSaveInput) -> bool {
+pub async fn workspace_save(app: tauri::AppHandle, args: WorkspaceSaveInput) -> bool {
+    if !allowed(&app, &args.vault_path) {
+        return false;
+    }
     let dir = Path::new(&args.vault_path).join(".noteriv");
     if fs::create_dir_all(&dir).is_err() {
         return false;

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -11,6 +11,7 @@ mod commands_window;
 mod commands_workspace;
 mod menu;
 mod paths;
+mod scope;
 mod shim;
 mod store;
 mod updater_cmds;
@@ -29,6 +30,8 @@ pub fn portable_root_public() -> Option<PathBuf> {
 pub struct AppState {
     pub clipper: Mutex<clipper::ClipperState>,
     pub watcher: Mutex<watcher::WatcherState>,
+    /// Paths the webview is permitted to reach. See `scope`.
+    pub scope: scope::PathScope,
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -41,6 +44,7 @@ pub fn run() {
     let app_state = AppState {
         clipper: Mutex::new(clipper::ClipperState::default()),
         watcher: Mutex::new(watcher::WatcherState::default()),
+        scope: scope::PathScope::default(),
     };
 
     let mut builder = tauri::Builder::default()

--- a/desktop/src-tauri/src/scope.rs
+++ b/desktop/src-tauri/src/scope.rs
@@ -1,0 +1,179 @@
+//! Runtime path scope for the file-system IPC commands.
+//!
+//! The webview is not a trusted caller. Note content, themes, CSS snippets and
+//! plugins all execute inside it, so any absolute path the renderer can pass to
+//! an `fs_*` command is a path an attacker-controlled script can pass too.
+//!
+//! A path is reachable only when the user has opted into it, either by
+//!   * registering the vault it lives in, or
+//!   * selecting it (or its parent directory) in a native file dialog.
+//!
+//! Paths are resolved before comparison, so `..` segments and symlinks cannot
+//! be used to step outside a permitted root. Resolution also covers paths that
+//! do not exist yet, which is the common case for a file about to be written.
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use crate::{paths, store};
+
+#[derive(Default)]
+pub struct PathScope {
+    /// Paths the user picked in a native dialog during this session.
+    granted: Mutex<HashSet<PathBuf>>,
+}
+
+impl PathScope {
+    /// Record a path the user explicitly chose in a native file dialog.
+    pub fn grant(&self, path: &str) {
+        if path.is_empty() {
+            return;
+        }
+        if let Ok(mut set) = self.granted.lock() {
+            set.insert(resolve(Path::new(path)));
+        }
+    }
+
+    /// True when the user picked this exact path, or a directory containing it,
+    /// in a native dialog this session. Deliberately narrower than
+    /// [`is_allowed`]: handing a path to the OS opener can start a process, so
+    /// vault membership alone is not sufficient authority.
+    pub fn is_granted(&self, path: &Path) -> bool {
+        let target = resolve(path);
+        self.granted
+            .lock()
+            .map(|set| set.iter().any(|g| target == *g || target.starts_with(g)))
+            .unwrap_or(false)
+    }
+
+    /// True when the path lies inside a registered vault or has been granted by
+    /// a dialog. The application's own data directory is always refused so the
+    /// credential store cannot be read back through the file commands, even if
+    /// a user points a vault at it.
+    pub fn is_allowed(&self, path: &Path) -> bool {
+        let target = resolve(path);
+
+        if let Ok(data_dir) = dunce::canonicalize(paths::user_data_dir()) {
+            if target.starts_with(&data_dir) {
+                return false;
+            }
+        }
+
+        if self.is_granted(&target) {
+            return true;
+        }
+
+        vault_roots().iter().any(|root| target.starts_with(root))
+    }
+}
+
+/// Canonicalized paths of every vault the user has registered.
+fn vault_roots() -> Vec<PathBuf> {
+    store::get_vaults()
+        .into_iter()
+        .filter_map(|v| dunce::canonicalize(&v.path).ok())
+        .collect()
+}
+
+/// Resolve `.`, `..` and symlinks as far as the path exists on disk.
+///
+/// A path that does not exist yet still has to be resolved, or a write to
+/// `<vault>/../../.bashrc` would slip through simply because the target file is
+/// absent. We canonicalize the nearest existing ancestor and re-append the
+/// remaining components to it.
+fn resolve(path: &Path) -> PathBuf {
+    if let Ok(p) = dunce::canonicalize(path) {
+        return p;
+    }
+
+    let mut trailing: Vec<std::ffi::OsString> = Vec::new();
+    let mut cursor = path.to_path_buf();
+
+    loop {
+        let Some(name) = cursor.file_name().map(|n| n.to_os_string()) else {
+            // A component we cannot name (a bare `..` or a root). Fail closed:
+            // return the path unchanged so it matches no permitted root.
+            return path.to_path_buf();
+        };
+        let Some(parent) = cursor.parent().map(|p| p.to_path_buf()) else {
+            return path.to_path_buf();
+        };
+
+        trailing.push(name);
+
+        if let Ok(base) = dunce::canonicalize(&parent) {
+            let mut out = base;
+            for component in trailing.iter().rev() {
+                out.push(component);
+            }
+            return out;
+        }
+
+        if parent.as_os_str().is_empty() {
+            return path.to_path_buf();
+        }
+        cursor = parent;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn tmp() -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("noteriv-scope-{}", std::process::id()));
+        let _ = fs::create_dir_all(&dir);
+        dunce::canonicalize(&dir).unwrap_or(dir)
+    }
+
+    #[test]
+    fn grant_allows_exact_path() {
+        let root = tmp();
+        let file = root.join("granted.md");
+        let _ = fs::write(&file, "x");
+        let scope = PathScope::default();
+        scope.grant(&file.to_string_lossy());
+        assert!(scope.is_granted(&file));
+    }
+
+    #[test]
+    fn granted_directory_covers_its_children() {
+        let root = tmp();
+        let sub = root.join("picked");
+        let _ = fs::create_dir_all(&sub);
+        let scope = PathScope::default();
+        scope.grant(&sub.to_string_lossy());
+        assert!(scope.is_granted(&sub.join("child.md")));
+    }
+
+    #[test]
+    fn ungranted_sibling_is_refused() {
+        let root = tmp();
+        let picked = root.join("picked");
+        let _ = fs::create_dir_all(&picked);
+        let scope = PathScope::default();
+        scope.grant(&picked.to_string_lossy());
+        assert!(!scope.is_granted(&root.join("other.md")));
+    }
+
+    #[test]
+    fn traversal_out_of_a_grant_is_refused() {
+        let root = tmp();
+        let picked = root.join("picked");
+        let _ = fs::create_dir_all(&picked);
+        let scope = PathScope::default();
+        scope.grant(&picked.to_string_lossy());
+        // Escapes `picked` even though the target does not exist.
+        assert!(!scope.is_granted(&picked.join("..").join("escaped.md")));
+    }
+
+    #[test]
+    fn resolve_handles_nonexistent_targets() {
+        let root = tmp();
+        let resolved = resolve(&root.join("does-not-exist-yet.md"));
+        assert!(resolved.starts_with(&root));
+        assert!(resolved.ends_with("does-not-exist-yet.md"));
+    }
+}

--- a/desktop/src-tauri/src/scope.rs
+++ b/desktop/src-tauri/src/scope.rs
@@ -72,6 +72,17 @@ impl PathScope {
             .unwrap_or(false)
     }
 
+    /// True when a directory entry reached by a recursive walk may be visited.
+    ///
+    /// The walking commands check the scope once, for the root they are given,
+    /// and then read whatever they find below it. A symlink inside that root can
+    /// point anywhere — a vault synchronizes from a Git remote, and Git carries
+    /// symlinks — so a linked entry has to clear the scope on its own. Ordinary
+    /// entries are already covered by the root's check.
+    pub fn may_visit(&self, file_type: &std::fs::FileType, path: &Path) -> bool {
+        !file_type.is_symlink() || self.is_allowed(path)
+    }
+
     /// True when the path lies inside a registered vault or has been granted by
     /// a dialog. The application's own data directory is always refused so the
     /// credential store cannot be read back through the file commands, even if
@@ -269,6 +280,34 @@ mod tests {
         let resolved = resolve(&root.join("does-not-exist-yet.md"));
         assert!(resolved.starts_with(&root));
         assert!(resolved.ends_with("does-not-exist-yet.md"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_walk_follows_a_symlink_only_when_its_target_is_in_scope() {
+        let root = tmp("walk");
+        let picked = root.join("picked");
+        let _ = fs::create_dir_all(&picked);
+        let outside = root.join("outside.md");
+        let _ = fs::write(&outside, "secret");
+        let inside = picked.join("real.md");
+        let _ = fs::write(&inside, "note");
+
+        let escaping = picked.join("escaping.md");
+        let contained = picked.join("contained.md");
+        let _ = fs::remove_file(&escaping);
+        let _ = fs::remove_file(&contained);
+        let _ = std::os::unix::fs::symlink(&outside, &escaping);
+        let _ = std::os::unix::fs::symlink(&inside, &contained);
+
+        let scope = PathScope::default();
+        scope.grant(&picked.to_string_lossy());
+
+        let kind = |p: &PathBuf| fs::symlink_metadata(p).unwrap().file_type();
+        assert!(scope.may_visit(&kind(&inside), &inside));
+        assert!(scope.may_visit(&kind(&contained), &contained));
+        // Reading this one would hand out a file the walk was never scoped for.
+        assert!(!scope.may_visit(&kind(&escaping), &escaping));
     }
 
     #[cfg(unix)]

--- a/desktop/src-tauri/src/scope.rs
+++ b/desktop/src-tauri/src/scope.rs
@@ -11,39 +11,64 @@
 //! Paths are resolved before comparison, so `..` segments and symlinks cannot
 //! be used to step outside a permitted root. Resolution also covers paths that
 //! do not exist yet, which is the common case for a file about to be written.
+//!
+//! Reading and writing is one authority; handing a path to the OS opener is
+//! another, because the opener starts a process. They are tracked separately —
+//! see [`PathScope::is_allowed`] and [`PathScope::is_openable`].
 
 use std::collections::HashSet;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::sync::Mutex;
 
 use crate::{paths, store};
 
 #[derive(Default)]
 pub struct PathScope {
-    /// Paths the user picked in a native dialog during this session.
-    granted: Mutex<HashSet<PathBuf>>,
+    /// Paths the user picked in a native dialog during this session. A picked
+    /// directory covers everything under it: choosing a folder is how the user
+    /// points the app at a set of files it may read and write.
+    readable: Mutex<HashSet<PathBuf>>,
+    /// Exactly the paths the user picked — never their children. See
+    /// [`PathScope::is_openable`] for why this set is not the one above.
+    openable: Mutex<HashSet<PathBuf>>,
 }
 
 impl PathScope {
     /// Record a path the user explicitly chose in a native file dialog.
+    ///
+    /// The choice grants file access to the path and anything below it, but
+    /// opener access only to the path itself.
     pub fn grant(&self, path: &str) {
         if path.is_empty() {
             return;
         }
-        if let Ok(mut set) = self.granted.lock() {
-            set.insert(resolve(Path::new(path)));
+        let resolved = resolve(Path::new(path));
+        if let Ok(mut set) = self.readable.lock() {
+            set.insert(resolved.clone());
+        }
+        if let Ok(mut set) = self.openable.lock() {
+            set.insert(resolved);
         }
     }
 
-    /// True when the user picked this exact path, or a directory containing it,
-    /// in a native dialog this session. Deliberately narrower than
-    /// [`is_allowed`]: handing a path to the OS opener can start a process, so
-    /// vault membership alone is not sufficient authority.
-    pub fn is_granted(&self, path: &Path) -> bool {
+    /// True when the user picked this exact path in a native dialog this
+    /// session.
+    ///
+    /// Deliberately narrower than [`is_allowed`](Self::is_allowed) in two ways.
+    /// Vault membership is not sufficient authority, because note content and
+    /// attachments arrive from sync, the web clipper and the MCP server without
+    /// the user ever choosing them. Nor is membership in a picked *directory*:
+    /// the vault folder itself is picked in a dialog, so descendants would
+    /// otherwise let a compromised renderer write an executable into the vault
+    /// and hand it to the opener. Only the exact path the user named counts.
+    pub fn is_openable(&self, path: &Path) -> bool {
         let target = resolve(path);
-        self.granted
+        if !is_comparable(&target) {
+            return false;
+        }
+        self.openable
             .lock()
-            .map(|set| set.iter().any(|g| target == *g || target.starts_with(g)))
+            .map(|set| set.contains(&target))
             .unwrap_or(false)
     }
 
@@ -53,6 +78,9 @@ impl PathScope {
     /// a user points a vault at it.
     pub fn is_allowed(&self, path: &Path) -> bool {
         let target = resolve(path);
+        if !is_comparable(&target) {
+            return false;
+        }
 
         if let Ok(data_dir) = dunce::canonicalize(paths::user_data_dir()) {
             if target.starts_with(&data_dir) {
@@ -60,12 +88,30 @@ impl PathScope {
             }
         }
 
-        if self.is_granted(&target) {
+        let granted = self
+            .readable
+            .lock()
+            .map(|set| set.iter().any(|g| target.starts_with(g)))
+            .unwrap_or(false);
+        if granted {
             return true;
         }
 
         vault_roots().iter().any(|root| target.starts_with(root))
     }
+}
+
+/// True when a resolved path can be compared against a permitted root.
+///
+/// `Path::starts_with` matches component by component, so it reports
+/// `<vault>/a/../../escaped.md` as living inside `<vault>`. Containment is only
+/// meaningful once every `.` and `..` is gone and the path is absolute;
+/// anything else is refused rather than compared.
+fn is_comparable(path: &Path) -> bool {
+    path.is_absolute()
+        && !path
+            .components()
+            .any(|c| matches!(c, Component::ParentDir | Component::CurDir))
 }
 
 /// Canonicalized paths of every vault the user has registered.
@@ -76,44 +122,55 @@ fn vault_roots() -> Vec<PathBuf> {
         .collect()
 }
 
-/// Resolve `.`, `..` and symlinks as far as the path exists on disk.
+/// Resolve `.`, `..` and symlinks, including for paths that do not exist yet.
 ///
-/// A path that does not exist yet still has to be resolved, or a write to
+/// A path that does not exist still has to be resolved, or a write to
 /// `<vault>/../../.bashrc` would slip through simply because the target file is
-/// absent. We canonicalize the nearest existing ancestor and re-append the
-/// remaining components to it.
+/// absent — and `<vault>/missing/../../escaped.md` has to resolve too, since a
+/// missing directory in the middle is enough to stop `canonicalize` outright.
+///
+/// Each `..` is applied to the *real* directory reached so far, not to the
+/// textual one. Collapsing `..` textually would be wrong: with `link` pointing
+/// at `/elsewhere`, `<vault>/link/../secret` names `/secret`, not
+/// `<vault>/secret`. Components that do not exist cannot be symlinks, so
+/// stepping up from them textually is sound.
 fn resolve(path: &Path) -> PathBuf {
+    let mut out = PathBuf::new();
+
+    for component in path.components() {
+        match component {
+            Component::Prefix(_) | Component::RootDir => out.push(component.as_os_str()),
+            Component::CurDir => {}
+            Component::ParentDir => {
+                if let Ok(real) = dunce::canonicalize(&out) {
+                    out = real;
+                }
+                out.pop();
+            }
+            Component::Normal(name) => out.push(name),
+        }
+    }
+
+    canonicalize_existing_prefix(&out)
+}
+
+/// Canonicalize the longest prefix of `path` that exists on disk and re-append
+/// the components that do not, so a file about to be created still resolves
+/// through the symlinks above it.
+///
+/// `path` is expected to be free of `.` and `..` — [`resolve`] consumes those
+/// before calling here.
+fn canonicalize_existing_prefix(path: &Path) -> PathBuf {
     if let Ok(p) = dunce::canonicalize(path) {
         return p;
     }
-
-    let mut trailing: Vec<std::ffi::OsString> = Vec::new();
-    let mut cursor = path.to_path_buf();
-
-    loop {
-        let Some(name) = cursor.file_name().map(|n| n.to_os_string()) else {
-            // A component we cannot name (a bare `..` or a root). Fail closed:
-            // return the path unchanged so it matches no permitted root.
-            return path.to_path_buf();
-        };
-        let Some(parent) = cursor.parent().map(|p| p.to_path_buf()) else {
-            return path.to_path_buf();
-        };
-
-        trailing.push(name);
-
-        if let Ok(base) = dunce::canonicalize(&parent) {
-            let mut out = base;
-            for component in trailing.iter().rev() {
-                out.push(component);
-            }
-            return out;
+    match (path.parent(), path.file_name()) {
+        (Some(parent), Some(name)) if !parent.as_os_str().is_empty() => {
+            let mut base = canonicalize_existing_prefix(parent);
+            base.push(name);
+            base
         }
-
-        if parent.as_os_str().is_empty() {
-            return path.to_path_buf();
-        }
-        cursor = parent;
+        _ => path.to_path_buf(),
     }
 }
 
@@ -122,58 +179,116 @@ mod tests {
     use super::*;
     use std::fs;
 
-    fn tmp() -> PathBuf {
-        let dir = std::env::temp_dir().join(format!("noteriv-scope-{}", std::process::id()));
+    /// A directory of its own for each test: they run in parallel and several
+    /// of them create and remove the same names.
+    fn tmp(case: &str) -> PathBuf {
+        let dir = std::env::temp_dir()
+            .join(format!("noteriv-scope-{}", std::process::id()))
+            .join(case);
         let _ = fs::create_dir_all(&dir);
         dunce::canonicalize(&dir).unwrap_or(dir)
     }
 
     #[test]
     fn grant_allows_exact_path() {
-        let root = tmp();
+        let root = tmp("exact");
         let file = root.join("granted.md");
         let _ = fs::write(&file, "x");
         let scope = PathScope::default();
         scope.grant(&file.to_string_lossy());
-        assert!(scope.is_granted(&file));
+        assert!(scope.is_allowed(&file));
+        assert!(scope.is_openable(&file));
     }
 
     #[test]
     fn granted_directory_covers_its_children() {
-        let root = tmp();
+        let root = tmp("children");
         let sub = root.join("picked");
         let _ = fs::create_dir_all(&sub);
         let scope = PathScope::default();
         scope.grant(&sub.to_string_lossy());
-        assert!(scope.is_granted(&sub.join("child.md")));
+        assert!(scope.is_allowed(&sub.join("child.md")));
     }
 
     #[test]
     fn ungranted_sibling_is_refused() {
-        let root = tmp();
+        let root = tmp("sibling");
         let picked = root.join("picked");
         let _ = fs::create_dir_all(&picked);
         let scope = PathScope::default();
         scope.grant(&picked.to_string_lossy());
-        assert!(!scope.is_granted(&root.join("other.md")));
+        assert!(!scope.is_allowed(&root.join("other.md")));
     }
 
     #[test]
     fn traversal_out_of_a_grant_is_refused() {
-        let root = tmp();
+        let root = tmp("traversal");
         let picked = root.join("picked");
         let _ = fs::create_dir_all(&picked);
         let scope = PathScope::default();
         scope.grant(&picked.to_string_lossy());
         // Escapes `picked` even though the target does not exist.
-        assert!(!scope.is_granted(&picked.join("..").join("escaped.md")));
+        assert!(!scope.is_allowed(&picked.join("..").join("escaped.md")));
+    }
+
+    #[test]
+    fn traversal_through_a_missing_directory_is_refused() {
+        let root = tmp("missing-dir");
+        let picked = root.join("picked");
+        let _ = fs::create_dir_all(&picked);
+        let scope = PathScope::default();
+        scope.grant(&picked.to_string_lossy());
+
+        // `new` does not exist, so the whole path cannot be canonicalized. The
+        // `..` segments still have to be applied, or the path keeps a `picked`
+        // prefix while naming a file two levels above it.
+        let escape = picked.join("new").join("..").join("..").join("escaped.md");
+        assert_eq!(resolve(&escape), root.join("escaped.md"));
+        assert!(!scope.is_allowed(&escape));
+    }
+
+    #[test]
+    fn opener_grant_does_not_cover_children() {
+        let root = tmp("opener");
+        let picked = root.join("picked");
+        let _ = fs::create_dir_all(&picked);
+        let scope = PathScope::default();
+        scope.grant(&picked.to_string_lossy());
+
+        // Picking a folder is authority to read and write inside it, but not to
+        // start whatever the renderer chooses to drop there.
+        let payload = picked.join("payload.sh");
+        assert!(scope.is_allowed(&payload));
+        assert!(!scope.is_openable(&payload));
+        assert!(scope.is_openable(&picked));
     }
 
     #[test]
     fn resolve_handles_nonexistent_targets() {
-        let root = tmp();
+        let root = tmp("nonexistent");
         let resolved = resolve(&root.join("does-not-exist-yet.md"));
         assert!(resolved.starts_with(&root));
         assert!(resolved.ends_with("does-not-exist-yet.md"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn parent_of_a_symlink_is_its_real_parent() {
+        let root = tmp("symlink");
+        let picked = root.join("picked");
+        let outside = root.join("outside");
+        let _ = fs::create_dir_all(&picked);
+        let _ = fs::create_dir_all(&outside);
+        let link = picked.join("link");
+        let _ = fs::remove_file(&link);
+        let _ = std::os::unix::fs::symlink(&outside, &link);
+
+        let scope = PathScope::default();
+        scope.grant(&picked.to_string_lossy());
+
+        // `link` resolves to `outside`, so `link/..` is `root`, not `picked`.
+        let escape = link.join("..").join("escaped.md");
+        assert_eq!(resolve(&escape), root.join("escaped.md"));
+        assert!(!scope.is_allowed(&escape));
     }
 }

--- a/desktop/src/components/markdown/mermaid.ts
+++ b/desktop/src/components/markdown/mermaid.ts
@@ -43,7 +43,13 @@ async function ensureMermaid(): Promise<typeof import("mermaid").default> {
           nodeTextColor: "#cdd6f4",
         },
         fontFamily: "'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif",
-        securityLevel: "loose",
+        // Diagram source is note content, and the rendered SVG goes to
+        // `innerHTML` below. Under `loose`, mermaid honours a diagram's `click`
+        // directive, so `click A "javascript:..."` in a note becomes a live
+        // `<a xlink:href="javascript:...">` in that SVG and runs in the
+        // application window when the node is clicked. `strict` — mermaid's own
+        // default — drops the href instead.
+        securityLevel: "strict",
       });
       mermaidInitialized = true;
     })();
@@ -114,6 +120,12 @@ class MermaidWidget extends WidgetType {
     const inner = document.createElement("div");
     inner.className = "mermaid-widget-inner";
     container.appendChild(inner);
+
+    // The SVG below is mermaid's own output, sanitized by mermaid under the
+    // `strict` level set in `ensureMermaid`. It deliberately does not also go
+    // through `lib/sanitize-html`: that configuration drops `<foreignObject>`,
+    // which is where mermaid puts every node label, so the diagrams would
+    // render as empty boxes.
 
     // Check cache first for synchronous render
     const cached = svgCache.get(this.source);

--- a/desktop/src/components/markdown/renderers/code-blocks.ts
+++ b/desktop/src/components/markdown/renderers/code-blocks.ts
@@ -499,10 +499,16 @@ class CodeBlockWidget extends WidgetType {
             nodeTextColor: textPrimary,
           },
           fontFamily: "'Inter', -apple-system, BlinkMacSystemFont, sans-serif",
-          securityLevel: "loose",
+          // See `markdown/mermaid.ts`: the diagram source is note content, and
+          // a `click` directive under `loose` puts a `javascript:` URL into the
+          // rendered SVG. `strict` is mermaid's default.
+          securityLevel: "strict",
         });
         const id = `mermaid-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
         const { svg } = await mermaid.render(id, this.code);
+        // Mermaid's own output, sanitized by mermaid at the `strict` level set
+        // above; see `markdown/mermaid.ts` for why it is not also run through
+        // `lib/sanitize-html`.
         if (container.isConnected) {
           inner.innerHTML = svg;
         }

--- a/desktop/src/components/markdown/renderers/tables.ts
+++ b/desktop/src/components/markdown/renderers/tables.ts
@@ -1,5 +1,6 @@
 import { Decoration, WidgetType, EditorView } from "@codemirror/view";
 import { RenderedMarkdownWidget } from "../widget";
+import { sanitizeHtml } from "@/lib/sanitize-html";
 import type { BlockRenderer, BlockContext } from "../types";
 
 const tableRowRegex = /^\|(.+)\|\s*$/;
@@ -19,6 +20,14 @@ function renderCell(cell: string): string {
   });
 }
 
+/**
+ * A row of a rendered table.
+ *
+ * Cell text is note content, so this widget carries the same injection risk as
+ * {@link RenderedMarkdownWidget} and sanitizes at the same point: where the
+ * markup reaches the document. It cannot reuse that widget because the cells
+ * need click handlers bound to the checkboxes inside them.
+ */
 class TableRowWidget extends WidgetType {
   constructor(
     readonly cellsHtml: string,
@@ -30,9 +39,15 @@ class TableRowWidget extends WidgetType {
   toDOM(view: EditorView) {
     const span = document.createElement("span");
     span.className = "md-table-row-inner";
-    span.innerHTML = this.cellsHtml;
+    span.innerHTML = sanitizeHtml(this.cellsHtml);
 
+    // Checkboxes are matched to document positions by their order in the row,
+    // so bind only when the row rendered exactly the ones we counted in the
+    // source line. Sanitizing can drop a cell that carried one, and cell text
+    // can carry markup that looks like one; either way the mapping is no longer
+    // trustworthy and a click would edit the wrong position.
     const cbEls = span.querySelectorAll<HTMLElement>(".md-table-checkbox");
+    if (cbEls.length !== this.checkboxes.length) return span;
     cbEls.forEach((el, i) => {
       const cb = this.checkboxes[i];
       if (!cb) return;

--- a/desktop/src/components/markdown/widget.ts
+++ b/desktop/src/components/markdown/widget.ts
@@ -1,6 +1,13 @@
 import { WidgetType } from "@codemirror/view";
+import { sanitizeHtml } from "@/lib/sanitize-html";
 
-/** A CodeMirror widget that renders arbitrary HTML inline. */
+/**
+ * A CodeMirror widget that renders HTML inline.
+ *
+ * Most callers pass markup this module generated itself, but the raw HTML block
+ * renderer passes note content straight through, so everything is sanitized
+ * here at the single point where it reaches the document.
+ */
 export class RenderedMarkdownWidget extends WidgetType {
   constructor(readonly html: string, readonly className: string) {
     super();
@@ -8,7 +15,7 @@ export class RenderedMarkdownWidget extends WidgetType {
   toDOM() {
     const span = document.createElement("span");
     span.className = this.className;
-    span.innerHTML = this.html;
+    span.innerHTML = sanitizeHtml(this.html);
     return span;
   }
   ignoreEvent(e: Event) {

--- a/desktop/src/lib/sanitize-html.ts
+++ b/desktop/src/lib/sanitize-html.ts
@@ -38,6 +38,24 @@ const ALLOWED_URI_REGEXP =
   /^(?:(?:https?|mailto|tel|blob):|data:(?:image|audio|video)\/|[^a-z]|[a-z+.\-]+(?:[^a-z+.\-:]|$))/i;
 
 /**
+ * Characters a URL parser discards, and that therefore let an attacker break up
+ * a scheme: `java\nscript:` reaches the parser as `javascript:`. Mirrors the set
+ * DOMPurify strips before applying its own URI check.
+ */
+const URL_IGNORED_CHARS =
+  /[\u0000-\u0020\u00A0\u1680\u180E\u2000-\u200D\u2028\u2029\u205F\u3000]/g;
+
+/**
+ * True when a URL may be placed in an `href` or `src`.
+ *
+ * Callers that assemble markup themselves need the same answer `sanitizeHtml`
+ * applies to attributes, so both read from one policy.
+ */
+export function isSafeUrl(url: string): boolean {
+  return ALLOWED_URI_REGEXP.test(url.replace(URL_IGNORED_CHARS, ""));
+}
+
+/**
  * Sanitize a fragment of HTML derived from note content.
  *
  * DOMPurify strips every `on*` event handler attribute, which is what closes
@@ -50,6 +68,12 @@ const ALLOWED_URI_REGEXP =
  * content before assembling it.
  */
 export function sanitizeHtml(dirty: string): string {
+  // DOMPurify needs a DOM to parse into, and there is none while Next
+  // prerenders. Nothing rendered in that pass carries note content, so drop the
+  // markup rather than return a string that was never checked.
+  if (!DOMPurify.isSupported) {
+    return "";
+  }
   return DOMPurify.sanitize(dirty, {
     FORBID_TAGS: FORBIDDEN_TAGS,
     // Belt and braces: DOMPurify already drops these, but naming them keeps the

--- a/desktop/src/lib/sanitize-html.ts
+++ b/desktop/src/lib/sanitize-html.ts
@@ -1,0 +1,64 @@
+/**
+ * HTML sanitization for markup that reaches `innerHTML`.
+ *
+ * Note content is untrusted. A vault synchronizes from a Git remote, a WebDAV
+ * share, a folder provider, the web clipper and the MCP server, so a note can
+ * carry markup the user never wrote. Anything derived from note content has to
+ * be sanitized before it is assigned to `innerHTML`, or the note becomes script
+ * running with the privileges of the application window.
+ */
+
+import DOMPurify from "dompurify";
+
+/** Elements that never appear in rendered markdown and can execute or embed. */
+const FORBIDDEN_TAGS = [
+  "script",
+  "iframe",
+  "object",
+  "embed",
+  "base",
+  "form",
+  "input",
+  "button",
+  "textarea",
+  "meta",
+  "link",
+];
+
+/**
+ * URL schemes a rendered note may reference.
+ *
+ * The renderer inlines local attachments as `data:` URLs (see
+ * `renderers/images.ts`), so `data:` cannot simply be refused. It is narrowed to
+ * media types instead, which keeps `data:text/html` — a navigable script
+ * context — out while leaving embedded images, audio and video working.
+ * `javascript:` matches nothing here and is dropped.
+ */
+const ALLOWED_URI_REGEXP =
+  /^(?:(?:https?|mailto|tel|blob):|data:(?:image|audio|video)\/|[^a-z]|[a-z+.\-]+(?:[^a-z+.\-:]|$))/i;
+
+/**
+ * Sanitize a fragment of HTML derived from note content.
+ *
+ * DOMPurify strips every `on*` event handler attribute, which is what closes
+ * the injection path. The forbid list removes elements that are meaningless in
+ * a rendered note but useful to an attacker.
+ *
+ * Note for callers: this parses the fragment in a neutral context, so markup
+ * that is only valid inside a specific parent — a bare `<td>`, `<tr>` or
+ * `<li>` — is unwrapped. Sanitize the complete element instead, or escape the
+ * content before assembling it.
+ */
+export function sanitizeHtml(dirty: string): string {
+  return DOMPurify.sanitize(dirty, {
+    FORBID_TAGS: FORBIDDEN_TAGS,
+    // Belt and braces: DOMPurify already drops these, but naming them keeps the
+    // intent visible if the default configuration ever changes.
+    FORBID_ATTR: ["srcdoc", "formaction", "xlink:href"],
+    ALLOWED_URI_REGEXP,
+    // Keep rendered output as a fragment; never let a note supply <html>/<body>.
+    WHOLE_DOCUMENT: false,
+    RETURN_DOM: false,
+    RETURN_DOM_FRAGMENT: false,
+  });
+}

--- a/desktop/src/lib/slide-utils.ts
+++ b/desktop/src/lib/slide-utils.ts
@@ -2,7 +2,13 @@
  * Slide presentation utilities.
  * Parses markdown into slides separated by `---` (horizontal rules)
  * and converts slide markdown to presentable HTML.
+ *
+ * Slides are built from note content and rendered with
+ * `dangerouslySetInnerHTML`, so `slideToHTML` sanitizes what it returns — see
+ * `lib/sanitize-html`.
  */
+
+import { sanitizeHtml, isSafeUrl } from "@/lib/sanitize-html";
 
 export interface Slide {
   content: string;   // markdown content
@@ -248,7 +254,7 @@ export function slideToHTML(md: string): string {
     }
   }
 
-  return html.join("\n");
+  return sanitizeHtml(html.join("\n"));
 }
 
 /**
@@ -260,16 +266,24 @@ function inlineFormat(text: string): string {
   // Inline code
   result = result.replace(/`([^`]+)`/g, '<code class="slide-inline-code">$1</code>');
 
-  // Images
+  // Images. The URL comes from the note, so a `javascript:` target has to be
+  // refused here rather than assembled into an attribute; markup that is not a
+  // safe link stays on the slide as the literal text the author wrote.
   result = result.replace(
     /!\[([^\]]*)\]\(([^)]+)\)/g,
-    '<img src="$2" alt="$1" class="slide-image">'
+    (whole, alt: string, url: string) =>
+      isSafeUrl(url)
+        ? `<img src="${url}" alt="${alt}" class="slide-image">`
+        : whole
   );
 
   // Links
   result = result.replace(
     /\[([^\]]+)\]\(([^)]+)\)/g,
-    '<a href="$2" class="slide-link">$1</a>'
+    (whole, label: string, url: string) =>
+      isSafeUrl(url)
+        ? `<a href="${url}" class="slide-link">${label}</a>`
+        : whole
   );
 
   // Bold + italic


### PR DESCRIPTION
Note content rendered in the desktop webview can execute script, and the IPC surface that script reaches is unscoped.

A vault is not authored solely by the person reading it. It synchronizes from a Git remote, a WebDAV share, a folder provider, the web clipper and the MCP server, so a note can carry markup its reader never wrote.

## Sanitize note-derived HTML

Raw HTML from a note reached `innerHTML` unchanged, so an attribute like `onerror` executed with the privileges of the application window. Sanitizing happens where markup reaches the document, at three points that each build their own element:

- `RenderedMarkdownWidget.toDOM`, which covers the inline and block renderers, including the raw HTML block renderer that passes note content straight through.
- `TableRowWidget.toDOM`. Table rows do not go through the widget above, because their cells need click handlers bound to the checkboxes inside them. Those handlers are matched to document positions by their order in the row, so they are bound only when the rendered row still holds exactly the checkboxes counted in the source line — sanitizing can drop a cell that carried one, and a stale mapping would edit the wrong position.
- `slideToHTML`, whose output the presentation renders with `dangerouslySetInnerHTML` on the stage, in the overview and in the print container. Link and image URLs are also tested against the same scheme policy before being placed in an attribute at all, so `[Open](javascript:...)` never becomes an `href`.

DOMPurify is added as a dependency. This is a deliberate exception to the "minimal dependencies" guidance in AGENTS.md: hand-rolled HTML sanitizers are a well-known source of bypasses, and the parsing quirks they have to cover are exactly what an attacker aims at.

Mermaid diagrams are a separate path. Both places that render one initialized mermaid with `securityLevel: "loose"`, under which a diagram's `click` directive is honoured, so `click A "javascript:..."` in a note becomes a live `<a xlink:href="javascript:...">` in the SVG that both widgets assign to `innerHTML`. They now use `strict`, which is mermaid's own default and drops the href. The SVG is deliberately not also passed through the app's sanitizer: that configuration drops `<foreignObject>`, which is where mermaid puts every node label, so diagrams would render as empty boxes.

## Scope webview file access

The webview is not a trusted caller. Note content, themes, CSS snippets and plugins all execute inside it, so any absolute path the renderer passes to a file command is a path an attacker-controlled script can pass too.

A new `PathScope` decides what the file commands, the workspace commands and the OS opener may touch. A path is reachable when the user has opted into it, either by registering the vault it lives in or by selecting it in a native dialog. The application's own data directory is always refused, so the credential store cannot be read back through the file commands even if a vault is pointed at it.

Reading and writing is one authority; handing a path to the OS opener is another, because the opener starts a process. They are tracked separately. A dialog grants file access to the picked path and everything below it — choosing a folder is how the user points the app at a set of files — but opener access only to the exact path named. A folder grant that covered its descendants would let a compromised renderer write an executable into a vault and start it.

Paths are resolved before they are compared to a permitted root, and resolution covers paths that do not exist yet, which is the common case for a file about to be written. Each `..` is applied to the real directory reached so far rather than the textual one: with `link` pointing at `/elsewhere`, `<vault>/link/../secret` names `/secret`. Components that do not exist cannot be symlinks, so stepping up from them textually is sound. Containment additionally refuses any path that still holds `.` or `..` after resolution, since `Path::starts_with` compares component by component and would otherwise report `<vault>/a/../../escaped.md` as living inside the vault.

The recursive commands — search, list and stat — check the scope once for the root they are given and then read what they find below it. A vault synchronizes from Git, and Git carries symlinks, so a link named `notes.md` pointing outside the vault was read and its matching lines returned. A linked entry now has to clear the scope on its own. Links that stay inside it keep working, and no walk follows linked directories, so there is still no way to build a cycle.

## Verification

- Nine unit tests over the scope module: exact and directory grants, refused siblings, traversal out of a grant, traversal through a directory that does not exist, opener grants not covering children, resolution of targets that do not exist, `..` across a symlink, and a walk refusing a link that leaves the scope.
- `cargo clippy` reports nothing on the code this PR adds. `tsc --noEmit` and `next build` are clean.
- Payloads run through the real sanitizer in a DOM: event-handler attributes, `<script>`, `<svg><animate onbegin>`, `javascript:` including the `java\nscript:` form and mixed case, and `data:text/html`.
- Each renderer's actual output was compared before and after sanitizing — callouts with their CSS custom property, inlined `data:image/*` attachments, image placeholders, remote images, links, autolinks, relative links, bullets, rules, table separators, footnotes, definition markers and table rows — to confirm nothing legitimate is altered.
- The mermaid behaviour was checked in a browser against this project's mermaid build: with `loose` the click executes, with `strict` it does not.

## Not covered

- Dialog grants are session-only, while workspace state persists external file paths, so a file opened from outside a vault is not readable again after a restart. Persisting grants needs a decision on where that store lives and how a grant is revoked or expires.
- `vault_create` is renderer-callable and unscoped, and registering a vault widens what is reachable, so script in the webview can register `/` as a vault and defeat the scoping above. Requiring a dialog grant fixes it but changes the setup wizard's default-path flow.
- The git commands take unscoped paths: `git_clone` writes a repo anywhere, and `git_init` and `git_show_file` are the same shape.
